### PR TITLE
Copy’s local plugins before running composer install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 # copy dep files first so Docker caches the install step if they don't change
 ONBUILD COPY composer.lock /app/user/
 ONBUILD COPY composer.json /app/user/
+ONBUILD COPY ./plugins /app/user/plugins
 # run install but without scripts as we don't have the app source yet
 ONBUILD RUN composer install --prefer-dist --no-scripts --no-suggest
 # require the buildpack for execution


### PR DESCRIPTION
This should fix local Craft plugin development using this Docker image.

Developing a Craft plugin as a local composer package wasn't possible because `composer install` runs before the local packages would actually be copied to the container, thus causing a composer install error. Volume mapping won't fix this issue because it doesn't apply to docker build's.